### PR TITLE
ENH improve linear model notebook

### DIFF
--- a/python_scripts/dev_linear_models.py
+++ b/python_scripts/dev_linear_models.py
@@ -28,24 +28,242 @@
 # ## 1. Regression: Linear regression
 
 # %% [markdown]
-# Before loading any dataset, we will first explore a very simple linear model:
-# our data is one dimensional, and the target value is continuous. For instance
-# our `x` might be the years of experiences (normalized) and `y` the salary
-# (normalized).
+# ### The over-simplistic toy example
+# To illustrate the main principle of linear regression, we will use a dataset
+# containing information about penguins.
 
 # %%
-import numpy as np
+import pandas as pd
+
+data = pd.read_csv("../datasets/penguins.csv")
+data.head()
+
+# %% [markdown]
+# This dataset contains features of penguins. We will formulate the following
+# problem. Observing the flipper length of a penguin, we would like to infer
+# is mass.
+
+# %%
+import seaborn as sns
+
+feature_names = "Flipper Length (mm)"
+target_name = "Body Mass (g)"
+
+sns.scatterplot(data=data, x=feature_names, y=target_name)
+
+# select the features of interest
+X = data[[feature_names]].dropna()
+y = data[target_name].dropna()
+
+# %% [markdown]
+# In this problem, the mass of a penguin is our target. It is a continuous
+# variable that roughly vary between 2700 g and 6300 g. Thus, this is a
+# regression problem (in contrast to classification). We also see that there is
+# almost linear relationship between the body mass of the penguin and the
+# flipper length. Longer is the flipper, heavier is the penguin.
+#
+# Thus, we could come with a simple rule that given a length of the flipper
+# we could compute the body mass of a penguin using a linear relationship of
+# of the form `y = a * x + b` where `a` and `b` are the 2 parameters of our
+# model.
+
+
+# %%
+def linear_model_flipper_mass(
+    flipper_length, weight_flipper_length, intercept_body_mass
+):
+    """Linear model of the form y = a * x + b"""
+    body_mass = weight_flipper_length * flipper_length + intercept_body_mass
+    return body_mass
+
+
+# %% [markdown]
+# Using the model that we define, we can check which body mass values we would
+# predict for a large range of flipper length.
+
+# %%
 import matplotlib.pyplot as plt
+import numpy as np
+
+
+def plot_data_and_model(
+    flipper_length_range, weight_flipper_length, intercept_body_mass,
+    ax=None,
+):
+    """Compute and plot the prediction."""
+    inferred_body_mass = linear_model_flipper_mass(
+        flipper_length_range,
+        weight_flipper_length=weight_flipper_length,
+        intercept_body_mass=intercept_body_mass,
+    )
+
+    if ax is None:
+        _, ax = plt.subplots()
+
+    sns.scatterplot(data=data, x=feature_names, y=target_name, ax=ax)
+    ax.plot(
+        flipper_length_range,
+        inferred_body_mass,
+        linewidth=3,
+        label=(
+            f"{weight_flipper_length:.2f} (g / mm) * flipper length + "
+            f"{intercept_body_mass:.2f} (g)"
+        ),
+    )
+    plt.legend()
+
+
+weight_flipper_length = 45
+intercept_body_mass = -5000
+
+flipper_length_range = np.linspace(X.min(), X.max(), num=300)
+plot_data_and_model(
+    flipper_length_range, weight_flipper_length, intercept_body_mass
+)
+
+# %% [markdown]
+# The variable `weight_flipper_length` is a weight applied to the feature in
+# order to make the inference. When this coefficient is positive, it means that
+# an increase of the flipper length will induce an increase of the body mass.
+# If the coefficient is negative, an increase of the flipper length will induce
+# a decrease of the body mass. Graphically, this coefficient is represented by
+# the slope of the curve that we draw.
+
+# %%
+weight_flipper_length = -40
+intercept_body_mass = 13000
+
+flipper_length_range = np.linspace(X.min(), X.max(), num=300)
+plot_data_and_model(
+    flipper_length_range, weight_flipper_length, intercept_body_mass
+)
+
+
+# %% [markdown]
+# In our case, this coefficient has some meaningful unit. Indeed, its unit is
+# g/mm. For instance, with a coefficient of 40 g/mm, it means that for an
+# additional millimeter, the body weight predicted will increase of 40 g.
+
+body_mass_180 = linear_model_flipper_mass(
+    flipper_length=180, weight_flipper_length=40, intercept_body_mass=0
+)
+body_mass_181 = linear_model_flipper_mass(
+    flipper_length=181, weight_flipper_length=40, intercept_body_mass=0
+)
+
+print(
+    f"The body mass for a flipper length of 180 mm is {body_mass_180} g and "
+    f"{body_mass_181} g for a flipper length of 181 mm"
+)
+
+# %% [markdown]
+# We can also see that we have a parameter `intercept_body_mass` in our model.
+# this parameter is the intercept of the curve when `x=0`. If the intercept is
+# null, then the curve will be passing by the origin:
+
+# %%
+weight_flipper_length = 25
+intercept_body_mass = 0
+
+flipper_length_range = np.linspace(0, X.max(), num=300)
+plot_data_and_model(
+    flipper_length_range, weight_flipper_length, intercept_body_mass
+)
+
+# %% [markdown]
+# Otherwise, it will be the value intercepted:
+
+# %%
+weight_flipper_length = 45
+intercept_body_mass = -5000
+
+flipper_length_range = np.linspace(0, X.max(), num=300)
+plot_data_and_model(
+    flipper_length_range, weight_flipper_length, intercept_body_mass
+)
+
+# %% [markdown]
+# Now, that we understood how our model is inferring data, one should question
+# on how to find the best value for the parameters. Indeed, it seems that we
+# can have several model which will depend of the choice of parameters:
+
+# %%
+_, ax = plt.subplots()
+flipper_length_range = np.linspace(X.min(), X.max(), num=300)
+for weight, intercept in zip([-40, 45, 90], [15000, -5000, -14000]):
+    plot_data_and_model(
+        flipper_length_range, weight, intercept, ax=ax,
+    )
+
+# %% [markdown]
+# To choose a model, we could use a metric indicating how good our model is
+# fitting our data.
+
+# %%
+from sklearn.metrics import mean_squared_error
+
+for weight, intercept in zip([-40, 45, 90], [15000, -5000, -14000]):
+    inferred_body_mass = linear_model_flipper_mass(
+        X,
+        weight_flipper_length=weight,
+        intercept_body_mass=intercept,
+    )
+    model_error = mean_squared_error(y, inferred_body_mass)
+    print(
+        f"The following model \n "
+        f"{weight:.2f} (g / mm) * flipper length + {intercept:.2f} (g) \n"
+        f"has a mean squared error of: {model_error:.2f}"
+    )
+
+# %% [markdown]
+# Hopefully, this problem can be solved without the need to check every
+# potential parameters combinations. Indeed, this problem as a closed-form
+# solution (i.e. an equation giving the parameter values) avoiding for any
+# brute-force search. This strategy is implemented in scikit-learn.
+
+# %%
+from sklearn.linear_model import LinearRegression
+
+linear_regression = LinearRegression()
+linear_regression.fit(X, y)
+
+# %% [markdown]
+# The instance `linear_regression` will store the parameter values in the
+# attribute `coef_` and `intercept_`. We can check which is the optimal model
+# found:
+
+# %%
+weight_flipper_length = linear_regression.coef_[0]
+intercept_body_mass = linear_regression.intercept_
+
+flipper_length_range = np.linspace(X.min(), X.max(), num=300)
+plot_data_and_model(
+    flipper_length_range, weight_flipper_length, intercept_body_mass
+)
+
+inferred_body_mass = linear_regression.predict(X)
+model_error = mean_squared_error(y, inferred_body_mass)
+print(f"The error of the optimal model is {model_error:.2f}")
+
+# %% [markdown]
+# ### What if your data don't have a linear relationship
+# Now, we will define a new problem where the feature and the target are not
+# linearly linked. For instance, we could defined `x` to be the years of
+# experience (normalized) and `y` the salary (normalized). Therefore, the
+# problem here would be to infer the salary given the years of experience of
+# someone.
+
+# %%
 
 # data generation
 # fix the seed for reproduction
-np.random.seed(0)
+rng = np.random.RandomState(0)
 
 n_sample = 100
 x_max, x_min = 1.4, -1.4
 len_x = (x_max - x_min)
-x = np.random.rand(n_sample) * len_x - len_x/2
-noise = np.random.randn(n_sample) * .3
+x = rng.rand(n_sample) * len_x - len_x/2
+noise = rng.randn(n_sample) * .3
 y = x ** 3 - 0.5 * x ** 2 + noise
 
 # plot the data
@@ -63,10 +281,8 @@ plt.ylabel('y', size=26)
 # Then you could compare the mean squared error of your model with the mean
 # squared error of a linear model (which shall be the minimal one).
 
+
 # %%
-from sklearn.metrics import mean_squared_error
-
-
 def f(x):
     w0 = 0  # TODO: update the weight here
     w1 = 0  # TODO: update the weight here
@@ -110,66 +326,6 @@ print(f'Lowest mean squared error = {mse}')
 print(f'best coef: w1 = {lr.coef_[0]}, best intercept: w0 = {lr.intercept_}')
 
 # %% [markdown]
-# ### Exercice 2
-# Here we will load some data from a real dataset. We will try to explain the mass of pinguins (`y`) given there flipper length (`x`)
-
-
-# %%
-import pandas as pd
-
-data = pd.read_csv("../datasets/penguins.csv")
-
-# select the features of interest
-x = data["Flipper Length (mm)"].dropna().to_numpy()
-y = data["Body Mass (g)"].dropna().to_numpy()
-
-# ploting the data
-plt.scatter(x, y, color = 'k')
-plt.xlabel("Flipper Length (mm)")
-plt.ylabel("Body Mass (g)")
-
-
-# %%
-def predict_body_mass(flipper_length):
-    w0 = -5000  # TODO: update the weight here [hint: between -5000 and -10000]
-    w1 = 40  # TODO: update the weight here [hint: between 40 and 70]
-    y_predict = w1 * flipper_length + w0
-    return y_predict
-
-# plot the slope of predict_body_mass
-x_max, x_min = 170, 235
-grid = np.linspace(x_min, x_max, 300)
-plt.scatter(x, y, color='k', s=9)
-plt.plot(grid, predict_body_mass(grid), linewidth=3)
-
-# %% [markdown]
-# ### Solution 2. Fiting a linear regression
-
-# %%
-from sklearn import linear_model
-
-lr = linear_model.LinearRegression()
-# X should be 2D for sklearn
-X = x.reshape((-1, 1))
-lr.fit(X, y)
-
-# plot the best slope
-y_best = lr.predict(grid.reshape(-1, 1))
-plt.plot(grid, y_best, linewidth=3)
-plt.scatter(x, y, color='k', s=9)
-
-mse = mean_squared_error(y, lr.predict(X))
-print(f'Lowest mean squared error = {mse}')
-
-# %%
-print(f'best coef: w1 = {lr.coef_[0]:.3}, best intercept: w0 = {lr.intercept_:.5}')
-
-# %% [markdown]
-# Here the coefficient w1 (=50) means that when a pinguin's flipper is 1 mm 
-# longer, the mass shall augment of 50g.
-# Here the intercept is not interpretable
-
-# %% [markdown]
 # ### Linear regression in higher dimension
 #
 # We will now load a new dataset from the “Current Population Survey” from 1985
@@ -195,9 +351,9 @@ X = X[numerical_columns]
 X.head()
 
 # %% [markdown]
-# Here we will divide our data into a training set and a validation set. 
+# Here we will divide our data into a training set and a validation set.
 # The validation set will be used to assert the hyper-parameters selection.
-# While a testing set should only be used to assert the score of our final 
+# While a testing set should only be used to assert the score of our final
 # model.
 
 # %%

--- a/python_scripts/dev_linear_models.py
+++ b/python_scripts/dev_linear_models.py
@@ -329,7 +329,7 @@ print(f'best coef: w1 = {lr.coef_[0]}, best intercept: w0 = {lr.intercept_}')
 # ### Linear regression in higher dimension
 #
 # We will now load a new dataset from the “Current Population Survey” from 1985
-# to predict the **Salary** as a function of various features such as
+# to predict the **salary** as a function of various features such as
 # *experience, age*, or *education*.
 # For simplicity, we will only use this numerical features.
 #
@@ -357,11 +357,11 @@ X.head()
 # model.
 
 # %%
-from sklearn.linear_model import LinearRegression, Ridge
+from sklearn.linear_model import Ridge
 from sklearn.model_selection import train_test_split
 
 X_train_valid, X_test, y_train_valid, y_test = train_test_split(
-    X, y, test_size = 5, random_state=1 
+    X, y, test_size=5, random_state=1
 )
 
 X_train, X_valid, y_train, y_valid = train_test_split(
@@ -410,8 +410,8 @@ linear_regression_score = model_linear.score(X_valid, y_valid)
 # Now we want to compare this basic `LinearRegression` versus its regularized
 # form `Ridge`.
 #
-# We will present the score on the validation set for different values of `alpha`,
-# which controls the regularization strength in `Ridge`.
+# We will present the score on the validation set for different values of
+# `alpha`, which controls the regularization strength in `Ridge`.
 
 # %%
 # taking the alpha between .01 and 100,
@@ -438,8 +438,8 @@ _ = plt.legend()
 
 # %% [markdown]
 # We see that, just like adding salt in cooking, adding regularization in our
-# model could improve its error on the validation set. But too much regularization,
-# like too much salt, decrease its performance.
+# model could improve its error on the validation set. But too much
+# regularization, like too much salt, decrease its performance.
 # In our case, the alpha parameters is best when is around 20.
 #
 # Note that the calibration of `alpha` could not be tuned on the test set -


### PR DESCRIPTION
I am proposing the following change.
I think it would be more intuitive to have the penguin example first and make a full description of the model.
Then we can introduce the example with the non-linearity as an exercise. At this point, people should moreless know the API and check the different attribute.